### PR TITLE
Segment name must not contain +, nor -,

### DIFF
--- a/GFA-spec.md
+++ b/GFA-spec.md
@@ -85,7 +85,7 @@ Comment lines begin with `#` and are ignored.
 | 2      | `Name`       | String    | `[!-)+-<>-~][!-~]*` | Segment name
 | 3      | `Sequence`   | String    | `\*|[A-Za-z=.]+`    | Optional nucleotide sequence
 
-Segment names must not contain whitespace characters or start with `*` or `=`. All other printable ASCII characters are allowed. Names are case sensitive.
+Segment names must not contain whitespace characters nor start with `*` or `=` nor contain the strings `+,` and `-,`. All other printable ASCII characters are allowed. Names are case sensitive.
 
 The Sequence field is optional and can be `*`, meaning that the nucleotide sequence of the segment is not specified. When the sequence is not stored in the GFA file, its length may be specified using the `LN` tag, and the sequence may be stored in an external FASTA file.
 


### PR DESCRIPTION
Commas are used to separate segment IDs in a path.

Closes #37.

This clarification is suggested by @lh3 in https://github.com/GFA-spec/GFA-spec/issues/37#issuecomment-248668734
> My recommendation is for GFA1, we test regex pattern /[+-],/ at an S-line. If we find a match, we throw an error, saying the current spec does not allow it. I think this treatment is working most of time in practice. I have seen commas in sequence names, but I am yet to see a /[+-],/ pattern – it is very rare.