### PR TITLE
Add ID tag to L and C lines

### DIFF
--- a/GFA-spec.md
+++ b/GFA-spec.md
@@ -128,6 +128,7 @@ The Overlap field is optional and can be `*`, meaning that the CIGAR string is n
 | `RC`  | `i`  | Read count
 | `FC`  | `i`  | Fragment count
 | `KC`  | `i`  | k-mer count
+| `ID`  | `Z`  | Edge identifier
 
 # `C` Containment line
 
@@ -151,6 +152,7 @@ A containment line represents an overlap between two segments where one is conta
 |-------|------|------------
 | `RC`  | `i`  | Read coverage
 | `NM`  | `i`  | Number of mismatches/gaps
+| `ID`  | `Z`  | Edge identifier
 
 # `P` Path line
 


### PR DESCRIPTION
The ID field can be e.g. used to store EdgeID identifiers when converting GFA2 files to the GFA1 format.
