### PR TITLE
Modify README to reflect that gfakluge can handle both GFA 1 and GFA 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 ## GFA 2
 
 + [gfalint](https://github.com/sjackman/gfalint)
-+ [GfaPy](https://github.com/ggonnella/gfapy)
 + [gfakluge](https://github.com/edawson/gfakluge)
++ [GfaPy](https://github.com/ggonnella/gfapy)
 
 ## GFA 1
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 
 + [gfalint](https://github.com/sjackman/gfalint)
 + [GfaPy](https://github.com/ggonnella/gfapy)
++ [gfakluge](https://github.com/edawson/gfakluge)
 
 ## GFA 1
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 
 ## GFA 2
 
-+ [gfalint](https://github.com/sjackman/gfalint)
 + [gfakluge](https://github.com/edawson/gfakluge)
++ [gfalint](https://github.com/sjackman/gfalint)
 + [GfaPy](https://github.com/ggonnella/gfapy)
 
 ## GFA 1


### PR DESCRIPTION
I've made a bunch of changes to [gfakluge](https://github.com/edawson/gfakluge) including full support for GFA2 and (where possible) conversion between the formats.

All I've done for the PR is add gfakluge to the list of GFA2 tools.

You can convert GFA 0.1 <-> 1.0 <-> subset(2.0) from the command line using the `gfa_spec_convert` tool:
`gfa_spec_convert -S 2.0 gfa_1.gfa > gfa_2.gfa`
Conversion kind of looks like this in C++:

      GFAKluge gg;
      // Parse a GFA1 file - get the version from the header.
      gg.parse_gfa_file("gfa1.gfa");

      // Change to GFA2
      gg.set_version(2.0);

      // write out to cout
      cout << gg.to_string();

      // Spit the same file out in block-ordered GFA1
      gg.set_version(1.0);
      cout << gg.block_order_string();



Also if anyone stress tests my code and finds I missed something, please let me know! I'd love some feedback.