### PR TITLE
GFA2: An integer may be signed

### DIFF
--- a/GFA2.md
+++ b/GFA2.md
@@ -60,7 +60,7 @@ assembly can be described.  Finally, one can describe and attach a name to any *
     <tag>       <- [A-Za-z0-9][A-Za-z0-9]:[ABHJZif]:[ -~]*
 
     <pos>       <- <int>{$}
-    <int>       <- [0-9]+
+    <int>       <- {-}[0-9]+
 
     <sequence>  <- * | [!-~]+
     <alignment> <- * | <trace> | <CIGAR>


### PR DESCRIPTION
The estimated gap distance may be negative.
A possible enhancement to the spec would specify which integers are constrained to positive integers.