### PR TITLE
Add GfaViz to the list of implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 + [gfakluge](https://github.com/edawson/gfakluge)
 + [gfalint](https://github.com/sjackman/gfalint)
 + [GfaPy](https://github.com/ggonnella/gfapy)
++ [GfaViz](https://github.com/ggonnella/gfaviz)
 
 ## GFA 1
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 + [Canu](https://github.com/marbl/canu)
 + [fermi mag2gfa](https://github.com/lh3/mag2gfa)
 + [gfakluge](https://github.com/edawson/gfakluge)
++ [GfaViz](https://github.com/ggonnella/gfaviz)
 + [jts/DALIGNER](https://github.com/jts/daligner)
 + [lh3/gfa1](https://github.com/lh3/gfa1)
 + [lh3/gfatools](https://github.com/lh3/gfatools)


### PR DESCRIPTION
After solving the issues on packaging open by @sjackman in GfaViz and tagging a stable v1.0.0 release, I request again to add the GfaViz implementation to the list.

This time I added it to both lists (GFA1 and GFA2). 