### PR TITLE
Add GfaPy also to the list of Gfa1 implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 + [Canu](https://github.com/marbl/canu)
 + [fermi mag2gfa](https://github.com/lh3/mag2gfa)
 + [gfakluge](https://github.com/edawson/gfakluge)
++ [GfaPy](https://github.com/ggonnella/gfapy)
 + [jts/DALIGNER](https://github.com/jts/daligner)
 + [lh3/gfa1](https://github.com/lh3/gfa1)
 + [lh3/gfatools](https://github.com/lh3/gfatools)


### PR DESCRIPTION
GfaPy was already in the list of GFA2 implementations. It also implements GFA1, thus it should also be added to that list as well.