### PR TITLE
[GFA1] Overlaps field in P, clarification

### DIFF
--- a/GFA1.md
+++ b/GFA1.md
@@ -177,7 +177,7 @@ C  1 - 2 + 110 100M
 | 3      | `SegmentNames` | String    | `[!-)+-<>-~][!-~]*`       | A comma-separated list of segment names and orientations
 | 4      | `Overlaps`     | String    | `\*\|([0-9]+[MIDNSHPX=])+` | Optional comma-separated list of CIGAR strings
 
-The `Overlaps` field is optional and can be `*`, in which case the `CIGAR` strings are determined by fetching the `CIGAR` string from the corresponding link records, or by performing a pairwise overlap alignment of the two sequences.
+The CIGAR strings in the `Overlaps` field are optional, and can be replaced by a `*`, in which case the `CIGAR` strings are determined by fetching the `CIGAR` string from the corresponding link records, or by performing a pairwise overlap alignment of the two sequences.
 
 ## Optional fields
 

--- a/GFA1.md
+++ b/GFA1.md
@@ -177,7 +177,7 @@ C  1 - 2 + 110 100M
 | 3      | `SegmentNames` | String    | `[!-)+-<>-~][!-~]*`       | A comma-separated list of segment names and orientations
 | 4      | `Overlaps`     | String    | `\*\|([0-9]+[MIDNSHPX=])+` | Optional comma-separated list of CIGAR strings
 
-The CIGAR strings in the `Overlaps` field are optional, and can be replaced by a `*`, in which case the `CIGAR` strings are determined by fetching the `CIGAR` string from the corresponding link records, or by performing a pairwise overlap alignment of the two sequences.
+The CIGAR strings in the `Overlaps` field are optional, and may be replaced by a `*`, in which case the `CIGAR` strings are determined by fetching the `CIGAR` string from the corresponding link records, or by performing a pairwise overlap alignment of the two sequences.
 
 ## Optional fields
 


### PR DESCRIPTION
I think it is necessary to make clear that the content of the "Overlaps" field in P lines is optional, but the field itself must be present. Some implementations (I noticed this in a TwoPaCo output) are producing invalid GFA, which does not have the field at all. The reason for this wrong implementation may lie in the confusing specification, in which the "Overlaps" field is listed in the "Required fields" list, but then it's written that it is optional, without explicitly saying that it shall be still present and contain a ```*``` placeholder. 