### PR TITLE
Clearer rules about element naming in GFA1

### DIFF
--- a/GFA1.md
+++ b/GFA1.md
@@ -51,11 +51,11 @@ All optional fields follow the `TAG:TYPE:VALUE` format where `TAG` is a two-char
 
 For type `B`, array of integers or floats, the first letter indicates the type of numbers in the following comma separated array. The letter can be one of `cCsSiIf`, corresponding to `int8_t` (signed 8-bit integer), `uint8_t` (unsigned 8-bit integer), `int16_t`, `uint16_t`, `int32_t`, `uint32_t` and `float`, respectively.
 
-## Names
+## Segment and path names
 
-Some lines, paths and segments, are identified by a name. Names shall be unique in the GFA file. All line types share the same namespace: i.e. a path cannot have the same name of a segment.
+Path and segment records are identified by a unique name. All record types share the same namespace, so a path may not have the same name as a segment.
 
-Names must not contain whitespace characters nor start with `*` or `=` nor contain the strings `+,` and `-,`. All other printable ASCII characters are allowed. Names are case sensitive.
+Names must not contain whitespace characters nor start with `*` or `=` nor contain the strings `+,` (plus comma) and `-,` (minus comma). All other printable ASCII characters are allowed. Names are case sensitive.
 
 # `#` Comment line
 

--- a/GFA1.md
+++ b/GFA1.md
@@ -51,6 +51,12 @@ All optional fields follow the `TAG:TYPE:VALUE` format where `TAG` is a two-char
 
 For type `B`, array of integers or floats, the first letter indicates the type of numbers in the following comma separated array. The letter can be one of `cCsSiIf`, corresponding to `int8_t` (signed 8-bit integer), `uint8_t` (unsigned 8-bit integer), `int16_t`, `uint16_t`, `int32_t`, `uint32_t` and `float`, respectively.
 
+## Names
+
+Some lines, paths and segments, are identified by a name. Names shall be unique in the GFA file. All line types share the same namespace: i.e. a path cannot have the same name of a segment.
+
+Names must not contain whitespace characters nor start with `*` or `=` nor contain the strings `+,` and `-,`. All other printable ASCII characters are allowed. Names are case sensitive.
+
 # `#` Comment line
 
 Comment lines begin with `#` and are ignored. 
@@ -84,8 +90,6 @@ Comment lines begin with `#` and are ignored.
 | 1      | `RecordType` | Character | `S`                 | Record type
 | 2      | `Name`       | String    | `[!-)+-<>-~][!-~]*` | Segment name
 | 3      | `Sequence`   | String    | `\*\|[A-Za-z=.]+`    | Optional nucleotide sequence
-
-Segment names must not contain whitespace characters nor start with `*` or `=` nor contain the strings `+,` and `-,`. All other printable ASCII characters are allowed. Names are case sensitive.
 
 The Sequence field is optional and can be `*`, meaning that the nucleotide sequence of the segment is not specified. When the sequence is not stored in the GFA file, its length may be specified using the `LN` tag, and the sequence may be stored in an external FASTA file.
 


### PR DESCRIPTION
Currently the specification does not clearly state that names are unique in a GFA1 file. Although in most implementations segment names are unique, this is not true for path names, which are sometimes equal to existing segment names. However, creates problems in the conversion to GFA2 (which requires IDs to be unique, with the exception of external sequences in fragments). Furthermore not having unique identifiers have other disadvantages: e.g. it breaks generic functions, which return a line of any kind from an ID, and does not allow to store named lines in dictionary-like structures.