### PR TITLE
Clarify cardinality constraint of Path Overlaps field compared to SegmentNames field

### DIFF
--- a/GFA1.md
+++ b/GFA1.md
@@ -181,9 +181,7 @@ C  1 - 2 + 110 100M
 | 3      | `SegmentNames` | String    | `[!-)+-<>-~][!-~]*`       | A comma-separated list of segment names and orientations
 | 4      | `Overlaps`     | String    | `\*\|([0-9]+[MIDNSHPX=])+` | Optional comma-separated list of CIGAR strings
 
-The CIGAR strings in the `Overlaps` field are optional, and may be replaced by a single `*` character, in which case the `CIGAR` strings are determined by fetching the `CIGAR` string from the corresponding link records, or by performing a pairwise overlap alignment of the two sequences.
-
-If specified, the `Overlaps` field must have one fewer values than the number of segment names and orientations in the `SegmentNames` field.
+The CIGAR strings in the `Overlaps` field are optional, and may be replaced by a single `*` character, in which case the `CIGAR` strings are determined by fetching the `CIGAR` string from the corresponding link records, or by performing a pairwise overlap alignment of the two sequences. If specified, the `Overlaps` field must have one fewer values than the number of segment names and orientations in the `SegmentNames` field.
 
 ## Optional fields
 

--- a/GFA1.md
+++ b/GFA1.md
@@ -181,7 +181,9 @@ C  1 - 2 + 110 100M
 | 3      | `SegmentNames` | String    | `[!-)+-<>-~][!-~]*`       | A comma-separated list of segment names and orientations
 | 4      | `Overlaps`     | String    | `\*\|([0-9]+[MIDNSHPX=])+` | Optional comma-separated list of CIGAR strings
 
-The CIGAR strings in the `Overlaps` field are optional, and may be replaced by a `*`, in which case the `CIGAR` strings are determined by fetching the `CIGAR` string from the corresponding link records, or by performing a pairwise overlap alignment of the two sequences.
+The CIGAR strings in the `Overlaps` field are optional, and may be replaced by a single `*` character, in which case the `CIGAR` strings are determined by fetching the `CIGAR` string from the corresponding link records, or by performing a pairwise overlap alignment of the two sequences.
+
+If specified, the `Overlaps` field must have one fewer values than the number of segment names and orientations in the `SegmentNames` field.
 
 ## Optional fields
 


### PR DESCRIPTION
I had a moment of confusion when looking at a test file [`t.gfa`](https://raw.githubusercontent.com/vgteam/odgi/master/test/t.gfa), which incorrectly has too many values in the `Overlaps` field.  It should have `SegmentNames.split(',').length() - 1` values.