### PR TITLE
Consider splitting Path line into Path and Traversal lines

### DIFF
--- a/GFA1.md
+++ b/GFA1.md
@@ -11,14 +11,14 @@ The master version of this document can be found at
 
 The purpose of the GFA format is to capture sequence graphs as the product of an assembly, a representation of variation in genomes, splice graphs in genes, or even overlap between reads from long-read sequencing technology.
 
-The GFA format is a tab-delimited text format for describing a set of sequences and their overlap. The first field of the line identifies the type of the line. Header lines start with `H`. Segment lines start with `S`. Link lines start with `L`. A containment line starts with `C`. A path line starts with `P`.
+The GFA format is a tab-delimited text format for describing a set of sequences and their overlap. The first field of the line identifies the type of the line. Header lines start with `H`. Segment lines start with `S`. Link lines start with `L`. A containment line starts with `C`. A path line starts with `P`. A path traversal line starts with `T`.
 
 ## Terminology
 
 + **Segment** a continuous sequence or subsequence.
 + **Link** an overlap between two segments. Each link is from the end of one segment to the beginning of another segment. The link stores the orientation of each segment and the amount of basepairs overlapping.
 + **Containment** an overlap between two segments where one is contained in the other.
-+ **Path** an ordered list of oriented segments, where each consecutive pair of oriented segments are supported by a link record.
++ **Path** an ordered list of traversals over oriented segments, where each consecutive pair of oriented segments are supported by a link record.
 
 ## Line structure
 
@@ -32,6 +32,7 @@ Each line in GFA has tab-delimited fields and the first field defines the type o
 | `L`  | Link        |
 | `C`  | Containment |
 | `P`  | Path        |
+| `T`  | Path traversal |
 
 ## Optional fields
 
@@ -217,8 +218,8 @@ L	11	+	12	-	4M
 L	12	-	13	+	5M
 L	11	+	13	+	3M
 P	14	2
-T   14  0  11 + 12 - 4M
-T   14  1  12 - 13 + 5M
+T	14	0	11	+	12	-	4M
+T	14	1	12	-	13	+	5M
 ```
 
 The resulting path is:

--- a/GFA1.md
+++ b/GFA1.md
@@ -178,10 +178,29 @@ C  1 - 2 + 110 100M
 |--------|----------------|-----------|---------------------------|--------------------
 | 1      | `RecordType`   | Character | `P`                       | Record type
 | 2      | `PathName`     | String    | `[!-)+-<>-~][!-~]*`       | Path name
-| 3      | `SegmentNames` | String    | `[!-)+-<>-~][!-~]*`       | A comma-separated list of segment names and orientations
-| 4      | `Overlaps`     | String    | `\*\|([0-9]+[MIDNSHPX=])+` | Optional comma-separated list of CIGAR strings
+| 3      | `Length`       | Integer   | `[0-9]*`                  | Path length, in number of traversal lines
 
-The CIGAR strings in the `Overlaps` field are optional, and may be replaced by a `*`, in which case the `CIGAR` strings are determined by fetching the `CIGAR` string from the corresponding link records, or by performing a pairwise overlap alignment of the two sequences.
+## Optional fields
+
+None specified.
+
+# `T` Path traversal line
+
+## Required fields
+
+| Column | Field        | Type      | Regexp                     | Description
+|--------|--------------|-----------|----------------------------|------------------
+| 1      | `RecordType` | Character | `T`                        | Record type
+| 2      | `PathName`   | String    | `[!-)+-<>-~][!-~]*`        | Path name for this traversal
+| 3      | `Ordinal`    | Integer   | `[0-9]*`                   | Ordinal or 0-based index for this traversal in its path
+| 2      | `From`       | String    | `[!-)+-<>-~][!-~]*`        | Name of segment
+| 3      | `FromOrient` | String    | `+\|-`                     | Orientation of From segment
+| 4      | `To`         | String    | `[!-)+-<>-~][!-~]*`        | Name of segment
+| 5      | `ToOrient`   | String    | `+\|-`                     | Orientation of `To` segment
+| 6      | `Overlap`    | String    | `\*\|([0-9]+[MIDNSHPX=])+` | Optional `CIGAR` string describing overlap
+
+The Overlap field is optional and can be `*`, meaning that the CIGAR string is not specified.
+In this case, the `CIGAR` string may be determined by fetching the `CIGAR` string from the corresponding link records, or by performing a pairwise overlap alignment of the two sequences.
 
 ## Optional fields
 
@@ -197,7 +216,9 @@ S	13	CTTGATT
 L	11	+	12	-	4M
 L	12	-	13	+	5M
 L	11	+	13	+	3M
-P	14	11+,12-,13+	4M,5M
+P	14	2
+T   14  0  11 + 12 - 4M
+T   14  1  12 - 13 + 5M
 ```
 
 The resulting path is:


### PR DESCRIPTION
Embedding potentially very large values into the `SegmentNames` and `Overlaps` columns of the `Path` line for GFA 1.0 prevents efficient columnar compression (the values are very large and almost guaranteed to be unique) and balanced partitioning for parallel analysis (`Path` lines are likely to be outliers in terms of size on disk and in RAM and also in terms of CPU cost to analyze).

Please consider splitting the `Path` line into separate `Path` and `Traversal` lines.  I will create this as a draft pull request in order to solicit feedback.