### PR TITLE
Define walk line in GFA1

### DIFF
--- a/GFA1.md
+++ b/GFA1.md
@@ -221,12 +221,12 @@ graph without overlaps between segments.
 |--------|-------------------|-----------|--------------------------|------------
 | 1      | `RecordType`      | Character | `W`                      | Record type
 | 2      | `SampleId`        | String    | `[!-)+-<>-~][!-~]*`      | Sample identifier
-| 3      | `PhaseIndex`      | Integer   | `[0-9]+`                 | Phase index (non-negative)
+| 3      | `HapIndex`        | Integer   | `[0-9]+`                 | Haplotype index
 | 4      | `SeqId`           | String    | `[!-)+-<>-~][!-~]*`      | Sequence identifier
 | 5      | `Walk`            | String    | `([><][!-;=?-~]+)+`      | Walk
 
-For a haploid sample, `PhaseIndex` takes 0. For a diploid or polyploid sample,
-`PhaseIndex` starts with 1. Tuple (`SampleId`,`PhaseIndex`,`SeqId`) is unique
+For a haploid sample, `HapIndex` takes 0. For a diploid or polyploid sample,
+`HapIndex` starts with 1. Tuple (`SampleId`,`HapIndex`,`SeqId`) is unique
 in an entire GFA file. A `Walk` is defined as
 ```txt
 <walk> ::= ( `>' | `<' <segId> )+
@@ -238,11 +238,11 @@ exist in the graph.
 
 ```txt
 H	VN:Z:1.0
-S	11	ACCTT
-S	12	TC
-S	13	GATT
-L	11	+	12	-	0M
-L	12	-	13	+	0M
-L	11	+	13	+	0M
-W	NA12878	1	chr1	>11<12>13
+S	s11	ACCTT
+S	s12	TC
+S	s13	GATT
+L	s11	+	s12	-	0M
+L	s12	-	s13	+	0M
+L	s11	+	s13	+	0M
+W	NA12878	1	chr1	>s11<s12>s13
 ```

--- a/GFA1.md
+++ b/GFA1.md
@@ -15,10 +15,10 @@ The GFA format is a tab-delimited text format for describing a set of sequences 
 
 ## Terminology
 
-+ **Segment** a continuous sequence or subsequence.
-+ **Link** an overlap between two segments. Each link is from the end of one segment to the beginning of another segment. The link stores the orientation of each segment and the amount of basepairs overlapping.
-+ **Containment** an overlap between two segments where one is contained in the other.
-+ **Path** an ordered list of oriented segments, where each consecutive pair of oriented segments are supported by a link record.
++ **Segment**: a continuous sequence or subsequence.
++ **Link**: an overlap between two segments. Each link is from the end of one segment to the beginning of another segment. The link stores the orientation of each segment and the amount of basepairs overlapping.
++ **Containment**: an overlap between two segments where one is contained in the other.
++ **Path** or **Walk**: an ordered list of oriented segments, where each consecutive pair of oriented segments are supported by a link record.
 
 ## Line structure
 

--- a/GFA1.md
+++ b/GFA1.md
@@ -210,6 +210,8 @@ The resulting path is:
 14 ACCTTGATT
 ```
 
+# GFA 1.1
+
 # `W` Walk line
 
 A walk line describes an oriented walk in the graph. It is only intended for a
@@ -224,8 +226,8 @@ not defined in the original GFAv1.
 | 2      | `SampleId`        | String    | `[!-)+-<>-~][!-~]*`      | Sample identifier
 | 3      | `HapIndex`        | Integer   | `[0-9]+`                 | Haplotype index
 | 4      | `SeqId`           | String    | `[!-)+-<>-~][!-~]*`      | Sequence identifier
-| 5      | `SeqStart`        | Integer   | `[0-9]+`                 | Start position
-| 6      | `SeqEnd`          | Integer   | `[0-9]+`                 | End position (BED-like half-close-half-open)
+| 5      | `SeqStart`        | Integer   | `\*\|[0-9]+`             | Optional Start position
+| 6      | `SeqEnd`          | Integer   | `\*\|[0-9]+`             | Optional End position (BED-like half-close-half-open)
 | 7      | `Walk`            | String    | `([><][!-;=?-~]+)+`      | Walk
 
 For a haploid sample, `HapIndex` takes 0. For a diploid or polyploid sample,

--- a/GFA1.md
+++ b/GFA1.md
@@ -210,9 +210,7 @@ The resulting path is:
 14 ACCTTGATT
 ```
 
-# GFA 1.1
-
-# `W` Walk line
+# `W` Walk line (since v1.1)
 
 A walk line describes an oriented walk in the graph. It is only intended for a
 graph without overlaps between segments. W-line was added in GFA v1.1 and was

--- a/GFA1.md
+++ b/GFA1.md
@@ -1,7 +1,7 @@
 ---
 title: Graphical Fragment Assembly (GFA) Format Specification
 author: The GFA Format Specification Working Group
-date: 2016-09-15
+date: 2022-02-11
 ---
 
 The master version of this document can be found at  

--- a/GFA1.md
+++ b/GFA1.md
@@ -32,6 +32,7 @@ Each line in GFA has tab-delimited fields and the first field defines the type o
 | `L`  | Link        |
 | `C`  | Containment |
 | `P`  | Path        |
+| `W`  | Walk        |
 
 ## Optional fields
 
@@ -207,4 +208,41 @@ The resulting path is:
 12  CCTTGA
 13   CTTGATT
 14 ACCTTGATT
+```
+
+# `W` Walk line
+
+A walk line describes an oriented walk in the graph. It is only intended for a
+graph without overlaps between segments.
+
+## Required fields
+
+| Column | Field             | Type      | Regexp                   | Description
+|--------|-------------------|-----------|--------------------------|------------
+| 1      | `RecordType`      | Character | `W`                      | Record type
+| 2      | `SampleId`        | String    | `[!-)+-<>-~][!-~]*`      | Sample identifier
+| 3      | `PhaseIndex`      | Integer   | `[0-9]+`                 | Phase index (non-negative)
+| 4      | `SeqId`           | String    | `[!-)+-<>-~][!-~]*`      | Sequence identifier
+| 5      | `Walk`            | String    | `([><][!-;=?-~]+)+`      | Walk
+
+For a haploid sample, `PhaseIndex` takes 0. For a diploid or polyploid sample,
+`PhaseIndex` starts with 1. Tuple (`SampleId`,`PhaseIndex`,`SeqId`) is unique
+in an entire GFA file. A `Walk` is defined as
+```txt
+<walk> ::= ( `>' | `<' <segId> )+
+```
+where `<segId>` corresponds to the identifier of a segment. A valid walk must
+exist in the graph.
+
+## Example
+
+```txt
+H	VN:Z:1.0
+S	11	ACCTT
+S	12	TC
+S	13	GATT
+L	11	+	12	-	0M
+L	12	-	13	+	0M
+L	11	+	13	+	0M
+W	NA12878	1	chr1	>11<12>13
 ```

--- a/GFA1.md
+++ b/GFA1.md
@@ -223,11 +223,14 @@ graph without overlaps between segments.
 | 2      | `SampleId`        | String    | `[!-)+-<>-~][!-~]*`      | Sample identifier
 | 3      | `HapIndex`        | Integer   | `[0-9]+`                 | Haplotype index
 | 4      | `SeqId`           | String    | `[!-)+-<>-~][!-~]*`      | Sequence identifier
-| 5      | `Walk`            | String    | `([><][!-;=?-~]+)+`      | Walk
+| 5      | `SeqStart`        | Integer   | `[0-9]+`                 | Start position
+| 6      | `SeqEnd`          | Integer   | `[0-9]+`                 | End position (BED-like half-close-half-open)
+| 7      | `Walk`            | String    | `([><][!-;=?-~]+)+`      | Walk
 
 For a haploid sample, `HapIndex` takes 0. For a diploid or polyploid sample,
-`HapIndex` starts with 1. Tuple (`SampleId`,`HapIndex`,`SeqId`) is unique
-in an entire GFA file. A `Walk` is defined as
+`HapIndex` starts with 1. For two W-lines with the same
+(`SampleId`,`HapIndex`,`SeqId`), their [`SeqSart`,`SeqEnd`) should have no
+overlaps. A `Walk` is defined as
 ```txt
 <walk> ::= ( `>' | `<' <segId> )+
 ```

--- a/GFA1.md
+++ b/GFA1.md
@@ -32,7 +32,7 @@ Each line in GFA has tab-delimited fields and the first field defines the type o
 | `L`  | Link        |
 | `C`  | Containment |
 | `P`  | Path        |
-| `W`  | Walk        |
+| `W`  | Walk (since v1.1) |
 
 ## Optional fields
 
@@ -213,7 +213,8 @@ The resulting path is:
 # `W` Walk line
 
 A walk line describes an oriented walk in the graph. It is only intended for a
-graph without overlaps between segments.
+graph without overlaps between segments. W-line was added in GFA v1.1 and was
+not defined in the original GFAv1.
 
 ## Required fields
 
@@ -240,7 +241,7 @@ exist in the graph.
 ## Example
 
 ```txt
-H	VN:Z:1.0
+H	VN:Z:1.1
 S	s11	ACCTT
 S	s12	TC
 S	s13	GATT

--- a/GFA1.md
+++ b/GFA1.md
@@ -247,5 +247,5 @@ S	s13	GATT
 L	s11	+	s12	-	0M
 L	s12	-	s13	+	0M
 L	s11	+	s13	+	0M
-W	NA12878	1	chr1	>s11<s12>s13
+W	NA12878	1	chr1	0	11	>s11<s12>s13
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 
 + GFA 2.0 is at [GFA2.md](GFA2.md)
 + GFA 1.0 is at [GFA1.md](GFA1.md)
++ GFA 1.1 is at [GFA1.md#gfa-11](GFA1.md#gfa-11)
 
 # Implementations
 
@@ -42,6 +43,12 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 + [vg](https://github.com/ekg/vg)
 + [w2rap](https://github.com/bioinfologics/w2rap-contigger)
 
+## GFA 1.1
+
++ [vg](https://github.com/ekg/vg)
++ [gbwt](https://github.com/jltsiren/gbwt)
++ [cactus pangenome pipeline](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/doc/pangenome.md)
+
 # Resources
 
 + [Examples](https://github.com/sjackman/assembly-graph) of sequence overlap graphs (assembly graphs) in a variety of formats
@@ -66,3 +73,7 @@ benefits from a standard encoding format that would make them all interoperable.
 # GFA 1.0
 
 GFA 1 was first suggested in a [blog post](http://lh3.github.io/2014/07/19/a-proposal-of-the-grapical-fragment-assembly-format) by Heng Li (@lh3) and further developed in a [second post](http://lh3.github.io/2014/07/23/first-update-on-gfa).
+
+# GFA 1.1
+
+W-lines were suggeseted by Heng Li (@lh3) as an extension to GFA 1 for representing haplotype information in pangenome graphs.  


### PR DESCRIPTION
This PR adds a new type of line, walk or W-line, to GFA1. It is similar to P-line but specialized for pangenome graphs with fixed fields for sample name, haplotype index and sequence name. The Human Pangenome Project may use this addition to encode human graphs.

Please don't merge. There are still details to be fleshed out.