### PR TITLE
Harmonize versions

### DIFF
--- a/GFA1.md
+++ b/GFA1.md
@@ -23,6 +23,7 @@ The GFA format is a tab-delimited text format for describing a set of sequences 
 ## Line structure
 
 Each line in GFA has tab-delimited fields and the first field defines the type of line. The type of the line defines the following required fields. The required fields are followed by optional fields.
+Parsers must ignore lines that begin with fields that they do not recognize.
 
 | Type | Description |
 |------|-------------|
@@ -32,7 +33,7 @@ Each line in GFA has tab-delimited fields and the first field defines the type o
 | `L`  | Link        |
 | `C`  | Containment |
 | `P`  | Path        |
-| `W`  | Walk (since v1.1) |
+| `W`  | Walk        |
 
 ## Optional fields
 
@@ -198,7 +199,7 @@ S	13	CTTGATT
 L	11	+	12	-	4M
 L	12	-	13	+	5M
 L	11	+	13	+	3M
-P	14	11+,12-,13+	4M,5M
+P	14	11+,12-,13+	*
 ```
 
 The resulting path is:
@@ -210,11 +211,10 @@ The resulting path is:
 14 ACCTTGATT
 ```
 
-# `W` Walk line (since v1.1)
+# `W` Walk line
 
-A walk line describes an oriented walk in the graph. It is only intended for a
-graph without overlaps between segments. W-line was added in GFA v1.1 and was
-not defined in the original GFAv1.
+A walk line describes an oriented walk in the graph. It is only intended for a graph without overlaps between segments.
+The walk allows the representation of approximate mappings between haplotypes and the graph, in contrast to P-lines which imply an exact, lossless mapping.
 
 ## Required fields
 
@@ -241,12 +241,13 @@ exist in the graph.
 ## Example
 
 ```txt
-H	VN:Z:1.1
+H	VN:Z:1.0
 S	s11	ACCTT
 S	s12	TC
 S	s13	GATT
 L	s11	+	s12	-	0M
 L	s12	-	s13	+	0M
 L	s11	+	s13	+	0M
+P	GRCh38#chr1	s11+,s12-,s13+ *
 W	NA12878	1	chr1	0	11	>s11<s12>s13
 ```

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ From 2015, P-lines have been employed to provide a positional system in pangenom
 
 W-lines were suggeseted by Heng Li (@lh3) as an extension to GFA 1 for representing lossy haplotype information in pangenome graphs.
 This need arises when building a pangenome graph using sequences with masked repeats, or when imputing short read data into a pangenome reference model.
+W-lines provide standard fields that are needed in this application, but are otherwise semantically equivalent to P-lines, and the two can be trivially converted with [gfa-wp](https://github.com/pangenome/gfa-wp).
 
 GFA 1 maintains backward compatibility with these and future user-level extensions by allowing parsers to not consider all line types.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 
 + GFA 2.0 is at [GFA2.md](GFA2.md)
 + GFA 1.0 is at [GFA1.md](GFA1.md)
-+ GFA 1.1 is at [GFA1.md#gfa-11](GFA1.md#gfa-11)
 
 # Implementations
 
@@ -22,13 +21,15 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 
 + [ABySS](https://github.com/bcgsc/abyss)
 + [Assembly Cytoscape3 App](http://apps.cytoscape.org/apps/assembly)
-+ [Bandage](https://rrwick.github.io/Bandage/)
++ [Bandage](https://github.com/asl/Bandage)
 + [bcalm2](https://github.com/GATB/bcalm)
 + [bfgraph](https://github.com/pmelsted/bfgraph)
++ [cactus pangenome pipeline](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/doc/pangenome.md)
 + [Canu](https://github.com/marbl/canu)
 + [Cuttlefish](https://github.com/COMBINE-lab/cuttlefish)
 + [dsh-bio](https://github.com/heuermh/dishevelled-bio)
 + [fermi mag2gfa](https://github.com/lh3/mag2gfa)
++ [gbwt](https://github.com/jltsiren/gbwt)
 + [gfabase](https://github.com/mlin/gfabase)
 + [gfakluge](https://github.com/edawson/gfakluge)
 + [GfaPy](https://github.com/ggonnella/gfapy)
@@ -39,22 +40,34 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 + [lmrodriguezr/gfa](https://github.com/lmrodriguezr/gfa)
 + [McCortex](https://github.com/mcveanlab/mccortex)
 + [miniasm](https://github.com/lh3/miniasm)
++ [ODGI toolkit](https://github.com/pangenome/odgi)
++ [PanGenome Graph Builder (pggb)](https://github.com/pangenome/pggb)
 + [RGFA](https://github.com/ggonnella/RGFA)
++ [seqwish](https://github.com/ekg/seqwish)
 + [SPAdes](http://cab.spbu.ru/software/spades/)
 + [TwoPaCo](https://github.com/medvedevgroup/TwoPaCo)
 + [Unicycler](https://github.com/rrwick/Unicycler)
 + [vg](https://github.com/ekg/vg)
 + [w2rap](https://github.com/bioinfologics/w2rap-contigger)
 
-## GFA 1.1
-
-+ [vg](https://github.com/ekg/vg)
-+ [gbwt](https://github.com/jltsiren/gbwt)
-+ [cactus pangenome pipeline](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/doc/pangenome.md)
-
 # Resources
 
 + [Examples](https://github.com/sjackman/assembly-graph) of sequence overlap graphs (assembly graphs) in a variety of formats
+
+# GFA 1.0
+
+GFA 1 was first suggested in a [blog post](http://lh3.github.io/2014/07/19/a-proposal-of-the-grapical-fragment-assembly-format) by Heng Li (@lh3) and further developed in a [second post](http://lh3.github.io/2014/07/23/first-update-on-gfa).
+Its original purpose was to represent assembly graphs.
+
+## Pangenome models and extensibility
+
+The GFA model was then adopted by Erik Garrison and others to represent [pangenome reference systems](https://doi.org/10.17863/CAM.41621).
+From 2015, P-lines have been employed to provide a positional system in pangenome graphs. These are now used in several tools (e.g. vg toolkit, odgi, and the maintained fork of Bandage).
+
+W-lines were suggeseted by Heng Li (@lh3) as an extension to GFA 1 for representing lossy haplotype information in pangenome graphs.
+This need arises when building a pangenome graph using sequences with masked repeats, or when imputing short read data into a pangenome reference model.
+
+GFA 1 maintains backward compatibility with these and future user-level extensions by allowing parsers to not consider all line types.
 
 # GFA 2.0: Graphical Fragment Assembly (GFA2) Format Specification 2.0
 
@@ -73,10 +86,3 @@ benefits from a standard encoding format that would make them all interoperable.
 
 ![Fig. 1](images/READ.Fig1.png)
 
-# GFA 1.0
-
-GFA 1 was first suggested in a [blog post](http://lh3.github.io/2014/07/19/a-proposal-of-the-grapical-fragment-assembly-format) by Heng Li (@lh3) and further developed in a [second post](http://lh3.github.io/2014/07/23/first-update-on-gfa).
-
-# GFA 1.1
-
-W-lines were suggeseted by Heng Li (@lh3) as an extension to GFA 1 for representing haplotype information in pangenome graphs.  


### PR DESCRIPTION
This removes v1.1 by making explicit the need for parsers to ignore unknown fields in v1.0. This makes explicit the _de facto_ behavior of virtually all tools.

The purpose of W-lines and P-lines is clarified, and their semantic equivalence indicated.

GFAv1 is clarified as being user-extensible.