### PR TITLE
Added optional SC tag to GFA2, similar to GFA1.2 + readme update

### DIFF
--- a/GFA-spec.md
+++ b/GFA-spec.md
@@ -1,4 +1,4 @@
 # GFA: Graphical Fragment Assembly
 
-+ The specification for GFA 2.0 is at [GFA2.md](GFA2.md)
-+ The specification for GFA 1.0 is at [GFA1.md](GFA1.md)
++ The specification for GFA 2 is at [GFA2.md](GFA2.md)
++ The specification for GFA 1 is at [GFA1.md](GFA1.md)

--- a/GFA1.md
+++ b/GFA1.md
@@ -1,7 +1,7 @@
 ---
 title: Graphical Fragment Assembly (GFA) Format Specification
 author: The GFA Format Specification Working Group
-date: 2022-02-11
+date: 2022-06-07
 ---
 
 The master version of this document can be found at  
@@ -299,7 +299,7 @@ Note that to specify usage of a jump connection rather than a regular link withi
 
 `J`-lines can also be used to specify _shortcut_ connections that do not correspond to any missing overlap or absent sequence.
 Shortcuts are primarily intended to be used within the `P`-lines to define arbitrary assembly scaffolds.
-Shortcut `J`-lines must be marked with as special tag: `SC:i:1`.
+Shortcut `J`-lines must be marked with a special tag: `SC:i:1`.
 
 ## Required fields
 

--- a/GFA1.md
+++ b/GFA1.md
@@ -213,7 +213,7 @@ The resulting path is:
 
 ## Extension to use jump connections (since v1.2)
 
-Version 1.2 expands the `P`-line format for usiging jump connections given by the `J`-lines (see "`J` Jump line" section).
+Version 1.2 expands the `P`-line format for using jump connections given by the `J`-lines (see "`J` Jump line" section).
 Semicolon (`;`) can now be used as a separator in `SegmentNames` in addition to a comma (`,`) to indicate the usage of a jump connection (defined by `J`-line), rather than a link connection (defined by `L`-line).
 If specified, the `Overlaps` field uses the `[-+]?[0-9]+J` format (note the `J` at the end to match the style of a `CIGAR` string) to refer to the jump connection with a particular estimated distance, and `.` if corresponding `J`-line does not provide distance estimate.
 
@@ -223,8 +223,6 @@ If specified, the `Overlaps` field uses the `[-+]?[0-9]+J` format (note the `J` 
 | 2      | `PathName`     | String    | `[!-)+-<>-~][!-~]*`       | Path name
 | 3      | `SegmentNames` | String    | `[!-)+-<>-~][!-~]*`       | A comma/semicolon-separated list of segment names and orientations
 | 4      | `Overlaps`     | String    | `\*\|([0-9]+[MIDNSHPX=]\|\[-+]?[0-9]+J\|.)+` | Optional comma-separated list of CIGAR strings and distance estimates
-
-*TODO suggestion to allow using `.` instead of any part of `Overlaps` that we do not actually need to disambiguate*
 
 ### Example
 
@@ -289,8 +287,6 @@ W	NA12878	1	chr1	0	11	>s11<s12>s13
 
 Jump lines are the mechanism to define the connections of segments which can not be associated with a particular overlap or sequence. Basic usecase is to represent 'gaps' corresponding to unassembled regions, most commonly due to absense or low quality of sequencing data.
 
-*TODO Should we 'bless' a tag to specify the source of the information about the connection?*
-
 `J`-lines specification generally follows one for `L`-lines, using columns 2-4 to specify connected segments and their respective orientations. 
 The only difference is that 6th column specifies a signed integer `Distance` (instead of the `Overlap` `CIGAR` string) -- estimated distance between the segments.
 The `Distance` can take a `*` value, meaning that the distance is not specified (estimate is unavailable).
@@ -299,11 +295,10 @@ Note that the `Distance` can take negative integer values, hinting at an undetec
 Since v1.2 jump connections can be used in the `P`-lines. 
 Note that to specify usage of a jump connection rather than a regular link within a path one should use a different separator (`;` instead of `,`). For details and examples see "Extension to use jump connections" subsection the `P`-line description.
 
-`J`-lines can also be used to specify long-range connections that do not imply direct adjecency between the connected segments.
+`J`-lines can also be used to specify long-range connections that do not imply direct adjacency between the connected segments.
 We will refer to such connections as _shortcuts_.
 Shortcuts are primarily intended to allow `P`-lines to define arbitrary assembly scaffolds.
-Shortcut `J`-lines must be marked with as special tag: `SC:Z:true`.
-*TODO discuss the tag*
+Shortcut `J`-lines must be marked with as special tag: `SC:i:1`.
 
 ## Required fields
 
@@ -320,12 +315,12 @@ Shortcut `J`-lines must be marked with as special tag: `SC:Z:true`.
 
 | Tag  | Type | Description
 |------|------|------------
-| `SC` | `Z`  | Marker tag for indirect shortcut connections. Value is ignored
+| `SC` | `i`  | 1 indicates indirect shortcut connections. Only 0/1 allowed.
 
 ## Example
 
 The following lines describe the jump between reverse complement of segment 1 and segment 2, with estimated distance of 100 and the  'shortcut' between segment 2 and reverse complement of segment 3 with unspecified distance.
 ```
 J  1 - 2 + 100
-J  2 + 3 - * SC:Z:true
+J  2 + 3 - * SC:i:1
 ```

--- a/GFA1.md
+++ b/GFA1.md
@@ -234,7 +234,7 @@ S	11	ACCTT
 S	12	TCAAGG
 S	13	CTTGATT
 L	11	+	12	-	4M
-J	11	+	12	-	*	SC:Z:true
+J	11	+	12	-	*	SC:i:1
 J	12	-	13	+	10
 P	first	11+,12-	*
 P	second	11+;12-	*

--- a/GFA1.md
+++ b/GFA1.md
@@ -250,3 +250,39 @@ L	s12	-	s13	+	0M
 L	s11	+	s13	+	0M
 W	NA12878	1	chr1	0	11	>s11<s12>s13
 ```
+
+# `J` Jump/Gap line (since v1.2)
+
+While not a concept for pure DeBrujin or long-read assemblers, it is the case that paired end data 
+and external maps often order and orient contigs/vertices into scaffolds with intervening gaps. 
+To this end we introduce a gap edge described in J-lines that give an arbitrary or estimated gap distance between the two segment sequences.
+The gap is between the first segment at left and the second segment at right where the segments are oriented according to their sign indicators. 
+The next integer gives the arbitrary or expected distance between the first and second segment in their respective orientations. 
+Relationships in E-lines are fixed and known, where as in a G-line, the distance is an estimate and the line type is intended to allow one to define assembly scaffolds.
+
+J-line was added in GFA v1.2 and was not defined in the original GFAv1. In addition, since J-lines can contribute to paths (P-lines), these have been further specified in v1.2.
+Particularly, a new separator `;` is introduced as opposed to `,` to distinguish whether the path is intended to use have a gap or an overlap link between the two segments being considered.
+
+## Required fields
+
+| Column | Field        | Type      | Regexp                   | Description
+|--------|--------------|-----------|--------------------------|------------------
+| 1      | `RecordType` | Character | `G`                      | Record type
+| 2      | `From`       | String    | `[!-)+-<>-~][!-~]*`      | Name of segment
+| 3      | `FromOrient` | String    | `+\|-`                   | Orientation of From segment
+| 4      | `To`         | String    | `[!-)+-<>-~][!-~]*`      | Name of segment
+| 5      | `ToOrient`   | String    | `+\|-`                   | Orientation of `To` segment
+| 6      | `Overlap`    | String    | `[0-9]+`                 | Arbitrary or expected distance between the segments
+
+## Example
+
+```
+H	VN:Z:1.2
+S	11	ACCTT
+S	12	TCAAGG
+S	13	CTTGATT
+G	11	+	12	-	10
+G	12	-	13	+	10
+G	11	+	13	+	3
+P	14	11+;12-;13+	*,*
+```

--- a/GFA1.md
+++ b/GFA1.md
@@ -16,9 +16,11 @@ The GFA format is a tab-delimited text format for describing a set of sequences 
 ## Terminology
 
 + **Segment**: a continuous sequence or subsequence.
-+ **Link** or **Jump**: a connection between two oriented segments. Each connection is from the end of one oriented segment to the beginning of another oriented segment. Links store the amount of basepairs overlapping, while jumps provide estimated distance between the segments.
++ **Link**: an overlap between two segments. Each link is from the end of one segment to the beginning of another segment. The link stores the orientation of each segment and the amount of basepairs overlapping.
++  **Jump**: (since v1.2) a connection between two oriented segments. Similar to link, but does not imply a direct adjacency between the segments, instead providing an estimated distance between the segments. Main use case is to specify segment relations across assembly gaps.
 + **Containment**: an overlap between two segments where one is contained in the other.
-+ **Path** or **Walk**: an ordered list of oriented segments, where each consecutive pair of oriented segments are supported by a link or a jump record.
++ **Path**: an ordered list of oriented segments, where each consecutive pair of oriented segments is supported by a link or a jump record.
++ **Walk**: (since v1.1) an ordered list of oriented segments, intended for pangenome use cases. Each consecutive pair of oriented segments must correspond to a 0-overlap link record.
 
 ## Line structure
 
@@ -295,9 +297,8 @@ Note that the `Distance` can take negative integer values, hinting at an undetec
 Since v1.2 jump connections can be used in the `P`-lines. 
 Note that to specify usage of a jump connection rather than a regular link within a path one should use a different separator (`;` instead of `,`). For details and examples see "Extension to use jump connections" subsection the `P`-line description.
 
-`J`-lines can also be used to specify long-range connections that do not imply direct adjacency between the connected segments.
-We will refer to such connections as _shortcuts_.
-Shortcuts are primarily intended to allow `P`-lines to define arbitrary assembly scaffolds.
+`J`-lines can also be used to specify _shortcut_ connections that do not correspond to any missing overlap or absent sequence.
+Shortcuts are primarily intended to be used within the `P`-lines to define arbitrary assembly scaffolds.
 Shortcut `J`-lines must be marked with as special tag: `SC:i:1`.
 
 ## Required fields

--- a/GFA1.md
+++ b/GFA1.md
@@ -267,7 +267,7 @@ Particularly, a new separator `;` is introduced as opposed to `,` to distinguish
 
 | Column | Field        | Type      | Regexp                   | Description
 |--------|--------------|-----------|--------------------------|------------------
-| 1      | `RecordType` | Character | `G`                      | Record type
+| 1      | `RecordType` | Character | `J`                      | Record type
 | 2      | `From`       | String    | `[!-)+-<>-~][!-~]*`      | Name of segment
 | 3      | `FromOrient` | String    | `+\|-`                   | Orientation of From segment
 | 4      | `To`         | String    | `[!-)+-<>-~][!-~]*`      | Name of segment
@@ -281,8 +281,8 @@ H	VN:Z:1.2
 S	11	ACCTT
 S	12	TCAAGG
 S	13	CTTGATT
-G	11	+	12	-	10
-G	12	-	13	+	10
-G	11	+	13	+	3
-P	14	11+;12-;13+	*,*
+J	11	+	12	-	10
+J	12	-	13	+	10
+J	11	+	13	+	3
+P	14	11+;12-;13+	;,;
 ```

--- a/GFA2.md
+++ b/GFA2.md
@@ -212,8 +212,7 @@ Such a collection could for example be highlighted by a drawing program on
 command, or might specify decisions about tours through the graph.  U-lines encode
 *unordered* collections and O-lines encode *ordered* collections (defined in the next paragraph),
 which we alternatively call **sets** and **paths**, respectively.
-The remainder of
-the line then consists of an optional ID for the collection followed by a non-empty list of ID's
+The remainder of the line then consists of an optional ID for the collection followed by a non-empty list of ID's
 referring to segments, edges, or other groups that are *separated by single spaces*
 (i.e. the list is in a single column of the tab-delimited format).  In the case of paths
 every reference must be oriented, and not so in a set.
@@ -230,6 +229,8 @@ orientation of the objects matters (e.g.
 the edge between two consecutive segments, the segment between two consecutive edges, etc.)
 A set can contain a reference to a path, but not vice versa, in which case the orientation
 of the objects in the path become irrelevant.
+Paths in the graph defined by O-lines can also specify subpaths of the components that need to be traversed.
+This is achieved using brackets and coordinates relative to the original orientation of the segment, e.g. ptg000124l.1(397101:505533)+
 
 Note: It was discussed whether U/O-lines with the same name could be considered to be concatenated together in the order in which they appear (see [#54](https://github.com/GFA-spec/GFA-spec/issues/54) and [#47](https://github.com/GFA-spec/GFA-spec/pull/47)). This multi-line path format was not included in the current version of this specification, but if people want to explore use of this structure, they can do so using a different single letter record code.
 

--- a/GFA2.md
+++ b/GFA2.md
@@ -203,7 +203,7 @@ estimate or a * indicating the variance is unknown.
 Relationships in E-lines are fixed and known, where as
 in a G-line, the distance is an estimate and the line type is intended to allow one to
 define assembly **scaffolds**. In this case, similar to `J`-lines in 
-[GFA1.2](https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md#j-jump-line-since-v12), 
+[GFA1.2](../GFA1.md#j-jump-line-since-v12), 
 `G`-lines specify _shortcut_ connections that do not correspond to any missing overlap or absent sequence.
 Such shortcut `G`-lines must be marked with a special tag: `SC:i:1`.
 

--- a/GFA2.md
+++ b/GFA2.md
@@ -212,7 +212,8 @@ Such a collection could for example be highlighted by a drawing program on
 command, or might specify decisions about tours through the graph.  U-lines encode
 *unordered* collections and O-lines encode *ordered* collections (defined in the next paragraph),
 which we alternatively call **sets** and **paths**, respectively.
-The remainder of the line then consists of an optional ID for the collection followed by a non-empty list of ID's
+The remainder of
+the line then consists of an optional ID for the collection followed by a non-empty list of ID's
 referring to segments, edges, or other groups that are *separated by single spaces*
 (i.e. the list is in a single column of the tab-delimited format).  In the case of paths
 every reference must be oriented, and not so in a set.
@@ -229,8 +230,6 @@ orientation of the objects matters (e.g.
 the edge between two consecutive segments, the segment between two consecutive edges, etc.)
 A set can contain a reference to a path, but not vice versa, in which case the orientation
 of the objects in the path become irrelevant.
-Paths in the graph defined by O-lines can also specify subpaths of the components that need to be traversed.
-This is achieved using brackets and coordinates relative to the original orientation of the segment, e.g. ptg000124l.1(397101:505533)+
 
 Note: It was discussed whether U/O-lines with the same name could be considered to be concatenated together in the order in which they appear (see [#54](https://github.com/GFA-spec/GFA-spec/issues/54) and [#47](https://github.com/GFA-spec/GFA-spec/pull/47)). This multi-line path format was not included in the current version of this specification, but if people want to explore use of this structure, they can do so using a different single letter record code.
 

--- a/GFA2.md
+++ b/GFA2.md
@@ -193,7 +193,7 @@ vertex-labelled form).  This is captured by edges for which beg1 = end1 = x$ and
 
 While not a concept for pure DeBrujin or long-read assemblers, it is the case that paired end
 data and external maps often order and orient contigs/vertices into scaffolds with
-intervening gaps.  To this end we introduce a **gap** edge described in G-lines that give the
+intervening gaps. To this end we introduce a **gap** edge described in G-lines that give the
 estimated gap distance between the two segment sequences and the variance of that estimate.
 The gap is between the first segment at left and the second
 segment at right where the segments are oriented according to their sign indicators.
@@ -202,7 +202,10 @@ respective orientations, and the final field is either an integer giving the var
 estimate or a * indicating the variance is unknown.
 Relationships in E-lines are fixed and known, where as
 in a G-line, the distance is an estimate and the line type is intended to allow one to
-define assembly **scaffolds**.
+define assembly **scaffolds**. In this case, similar to `J`-lines in 
+[GFA1.2](https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md#j-jump-line-since-v12), 
+`G`-lines specify _shortcut_ connections that do not correspond to any missing overlap or absent sequence.
+Such shortcut `G`-lines must be marked with a special tag: `SC:i:1`.
 
 ### Group
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 + [gfalint](https://github.com/sjackman/gfalint)
 + [GfaPy](https://github.com/ggonnella/gfapy)
 + [GfaViz](https://github.com/ggonnella/gfaviz)
++ [gfastats](https://github.com/vgl-hub/gfastats)
 
 ## GFA 1
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 + [gfalint](https://github.com/sjackman/gfalint)
 + [GfaPy](https://github.com/ggonnella/gfapy)
 + [GfaViz](https://github.com/ggonnella/gfaviz)
-+ [gfastats](https://github.com/vgl-hub/gfastats)
 
 ## GFA 1
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 + GFA 2.0 is at [GFA2.md](GFA2.md)
 + GFA 1.0 is at [GFA1.md](GFA1.md)
 + GFA 1.1 is at [GFA1.md#gfa-11](GFA1.md#gfa-11)
++ GFA 1.2 is at [GFA1.md#gfa-11](GFA1.md#j-jump-line-since-v12)
 
 # Implementations
 
@@ -52,6 +53,10 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 + [gbwt](https://github.com/jltsiren/gbwt)
 + [cactus pangenome pipeline](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/doc/pangenome.md)
 
+## GFA 1.2
+
++ [gfastats](https://github.com/vgl-hub/gfastats)
+
 # Resources
 
 + [Examples](https://github.com/sjackman/assembly-graph) of sequence overlap graphs (assembly graphs) in a variety of formats
@@ -80,3 +85,7 @@ GFA 1 was first suggested in a [blog post](http://lh3.github.io/2014/07/19/a-pro
 # GFA 1.1
 
 W-lines were suggeseted by Heng Li (@lh3) as an extension to GFA 1 for representing haplotype information in pangenome graphs.  
+
+# GFA 1.2
+
+J-lines were suggested by Sergey Nurk and Giulio Formenti as an extension to GFA 1.1 to represent jumps in graphs such as gaps in assembly scaffolds.


### PR DESCRIPTION
Based on a discussion with @snurk it seems useful to ensure the presence of a tag to specify shortcut connections among the possible types of gap lines