### PR TITLE
Add GGCAT to supporting tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 + [gfalint](https://github.com/sjackman/gfalint)
 + [GfaPy](https://github.com/ggonnella/gfapy)
 + [GfaViz](https://github.com/ggonnella/gfaviz)
++ [GGCAT](https://github.com/algbio/ggcat/)
 
 ## GFA 1
 
@@ -33,6 +34,7 @@ We are developing the specification of the Graphical Fragment Assembly (GFA) for
 + [gfakluge](https://github.com/edawson/gfakluge)
 + [GfaPy](https://github.com/ggonnella/gfapy)
 + [GfaViz](https://github.com/ggonnella/gfaviz)
++ [GGCAT](https://github.com/algbio/ggcat/)
 + [jts/DALIGNER](https://github.com/jts/daligner)
 + [lh3/gfa1](https://github.com/lh3/gfa1)
 + [lh3/gfatools](https://github.com/lh3/gfatools)


### PR DESCRIPTION
GGCAT in its latest version supports both GFA1 and GFA2 output.