### PR TITLE
Compression of haplotype walks

### DIFF
--- a/GFA1.md
+++ b/GFA1.md
@@ -360,7 +360,7 @@ where `<segId>` corresponds either to the identifier of a segment or the identif
 ## Example
 
 ```txt
-Q	@q1	>s1<s60>s75>@q3>s77		LN:8188	LS:9
+Q	@q1	>s1<s60>s75>@q3>s77		LN:i:8188	LS:i:9
 Q	@q3	>s78>s79>s80>s80<s80
 ```
 

--- a/GFA1.md
+++ b/GFA1.md
@@ -352,9 +352,6 @@ where `<segId>` corresponds either to the identifier of a segment or the identif
 |-------|------|----------------|
 | `LN`  | `i`  | Length in number of base pairs |
 | `LS`  | `i`  | Length in number of segments  |
-| `FN`  | `Z`  | Feature name |
-| `FT`  | `Z`  | Feature type |
-| `DB`  | `X`  | Database cross-references |
 
 ## Example
 

--- a/GFA1.md
+++ b/GFA1.md
@@ -340,8 +340,8 @@ compressed walks, so called meta-segments.
 | Column | Field             | Type      | Regexp                | Description
 |--------|-------------------|-----------|-----------------------|------------
 | 1      | `RecordType`      | Character | `Q`                   | Record type
-| 2      | `Name`            | String    | `@[!-)+-<>?A-~][!-~]*` | Rule name
-| 3      | `CompressedWalk`  | String    | `([><]@?[!-;=?-~]+)+` | Compressed Walk
+| 2      | `Name`            | String    | `@[!-)+\--:?A-~][!-+\--:=?-~]*` | Rule name
+| 3      | `CompressedWalk`  | String    | `([><]@?[!-)+\--:?A-~][!-+\--:=?-~]*)+` | Compressed Walk
 
 A `CompressedWalk` is defined as
 ```txt
@@ -380,7 +380,7 @@ Note that Z-lines can not use jump connections (introduced in v1.2).
 | 4      | `SeqId`           | String    | `[!-)+-<>-~][!-~]*`      | Sequence identifier
 | 5      | `SeqStart`        | Integer   | `\*\|[0-9]+`             | Optional Start position
 | 6      | `SeqEnd`          | Integer   | `\*\|[0-9]+`             | Optional End position (BED-like half-close-half-open)
-| 7      | `CompressedWalk`  | String    | `([><]@?[!-;=?-~]+)+`    | Compressed Walk
+| 7      | `CompressedWalk`  | String    | `([><]@?[!-)+\--:?A-~][!-+\--:=?-~]*)+`    | Compressed Walk
 
 For a haploid sample, `HapIndex` takes 0. For a diploid or polyploid sample,
 `HapIndex` starts with 1. For two W-lines with the same

--- a/GFA1.md
+++ b/GFA1.md
@@ -340,7 +340,7 @@ compressed walks, so called meta-segments.
 | Column | Field             | Type      | Regexp                | Description
 |--------|-------------------|-----------|-----------------------|------------
 | 1      | `RecordType`      | Character | `Q`                   | Record type
-| 2      | `Name`            | String    | `[!-)+-<>?A-~][!-~]*` | Rule name
+| 2      | `Name`            | String    | `@[!-)+-<>?A-~][!-~]*` | Rule name
 | 3      | `CompressedWalk`  | String    | `([><]@?[!-;=?-~]+)+` | Compressed Walk
 
 A `CompressedWalk` is defined as
@@ -360,8 +360,8 @@ where `<segId>` corresponds either to the identifier of a segment or the identif
 ## Example
 
 ```txt
-Q	q1	>s1<s60>s75>@q3>s77		LN:8188	LS:9
-Q	q3	>s78>s79>s80>s80<s80
+Q	@q1	>s1<s60>s75>@q3>s77		LN:8188	LS:9
+Q	@q3	>s78>s79>s80>s80<s80
 ```
 
 # `Z` Compressed walk line (since v1.3)
@@ -401,6 +401,6 @@ S	s13	GATT
 L	s11	+	s12	-	0M
 L	s12	-	s13	+	0M
 L	s11	+	s13	+	0M
-Q   q1  >s11<s12
+Q   @q1  >s11<s12
 Z	NA12878	1	chr1	0	11	>@q1>s13
 ```

--- a/GFA1.md
+++ b/GFA1.md
@@ -21,6 +21,8 @@ The GFA format is a tab-delimited text format for describing a set of sequences 
 + **Containment**: an overlap between two segments where one is contained in the other.
 + **Path**: an ordered list of oriented segments, where each consecutive pair of oriented segments is supported by a link or a jump record.
 + **Walk**: (since v1.1) an ordered list of oriented segments, intended for pangenome use cases. Each consecutive pair of oriented segments must correspond to a 0-overlap link record.
++ **Meta-segment**: (since v1.3) a segment that is used as a stand-in for multiple other segments.
++ **Compressed Walk**: (since v1.3) an ordered list of oriented segments, intended for pangenome use cases. Unlike a walk record it can contain meta-segments.
 
 ## Line structure
 
@@ -36,6 +38,8 @@ Each line in GFA has tab-delimited fields and the first field defines the type o
 | `C`  | Containment |
 | `P`  | Path        |
 | `W`  | Walk (since v1.1) |
+| `Q`  | Meta-segment (since v1.3) |
+| `Z`  | Compressed Walk (since v1.3) |
 
 ## Optional fields
 
@@ -326,7 +330,7 @@ J  1 - 2 + 100
 J  2 + 3 - * SC:i:1
 ```
 
-# `Q` Meta-segment line
+# `Q` Meta-segment line (since v1.3)
 
 A Q-line defines part of a compressed walk that can be used as part of other
 compressed walks, so called meta-segments.
@@ -360,7 +364,7 @@ Q	q1	>s1<s60>s75>@q3>s77		LN:8188	LS:9
 Q	q3	>s78>s79>s80>s80<s80
 ```
 
-# `Z` Compressed walk line
+# `Z` Compressed walk line (since v1.3)
 
 A walk line describes an oriented walk in the graph. It is only intended for a
 graph without overlaps between segments.

--- a/GFA1.md
+++ b/GFA1.md
@@ -50,7 +50,6 @@ All optional fields follow the `TAG:TYPE:VALUE` format where `TAG` is a two-char
 | `J`  | `[ !-~]+`                                             | [JSON][], excluding new-line and tab characters
 | `H`  | `[0-9A-F]+`                                           | Byte array in hex format
 | `B`  | `[cCsSiIf](,[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)+` | Array of integers or floats
-| `X`  | `[ -+\--~]+,[ -+\--~]+,(\*|[0-9]+),(\*|[0-9]+)(,[ -+\--~]+,[ -+\--~]+,(\*|[0-9]+),(\*|[0-9]+))*` | Array of database cross-references
 
 [JSON]: http://json.org/
 
@@ -327,25 +326,25 @@ J  1 - 2 + 100
 J  2 + 3 - * SC:i:1
 ```
 
-# `Q` Rule line
+# `Q` Meta-segment line
 
 A Q-line defines part of a compressed walk that can be used as part of other
-compressed walks.
+compressed walks, so called meta-segments.
 
 ## Required fields
 
-| Column | Field             | Type      | Regexp              | Description
-|--------|-------------------|-----------|---------------------|------------
-| 1      | `RecordType`      | Character | `Q`                 | Record type
-| 2      | `Name`            | String    | `[!-)+-<>-~][!-~]*` | Rule name
-| 3      | `CompressedWalk`  | String    | `([><][!-;=?-~]+)+` | Compressed Walk
+| Column | Field             | Type      | Regexp                | Description
+|--------|-------------------|-----------|-----------------------|------------
+| 1      | `RecordType`      | Character | `Q`                   | Record type
+| 2      | `Name`            | String    | `[!-)+-<>?A-~][!-~]*` | Rule name
+| 3      | `CompressedWalk`  | String    | `([><]@?[!-;=?-~]+)+` | Compressed Walk
 
 A `CompressedWalk` is defined as
 ```txt
-<walk> ::= ( `>' | `<' <segId> )+
+<walk> ::= ( `>' | `<' `@'? <segId> )+
 ```
-where `<segId>` corresponds either to the identifier of a segment or the
-identifier of a Q-line. A valid walk must exist in the graph.
+where `<segId>` corresponds either to the identifier of a segment or the identifier of a Q-line. A valid walk must exist in the graph.
+`@` is placed in front of the segment identifier if the segment is a meta-segment.
 
 ## Optional fields
 
@@ -360,7 +359,7 @@ identifier of a Q-line. A valid walk must exist in the graph.
 ## Example
 
 ```txt
-Q	q1	>s1<s60>s75>q3>s77	FN:Z:MICA	FT:Z:gene	DB:X:EMBL,AA816246,*,*,NCBI_gi,100507436,437,8625		LN:8188	LS:9
+Q	q1	>s1<s60>s75>@q3>s77		LN:8188	LS:9
 Q	q3	>s78>s79>s80>s80<s80
 ```
 
@@ -380,17 +379,17 @@ Note that Z-lines can not use jump connections (introduced in v1.2).
 | 4      | `SeqId`           | String    | `[!-)+-<>-~][!-~]*`      | Sequence identifier
 | 5      | `SeqStart`        | Integer   | `\*\|[0-9]+`             | Optional Start position
 | 6      | `SeqEnd`          | Integer   | `\*\|[0-9]+`             | Optional End position (BED-like half-close-half-open)
-| 7      | `CompressedWalk`  | String    | `([><][!-;=?-~]+)+`      | Compressed Walk
+| 7      | `CompressedWalk`  | String    | `([><]@?[!-;=?-~]+)+`    | Compressed Walk
 
 For a haploid sample, `HapIndex` takes 0. For a diploid or polyploid sample,
 `HapIndex` starts with 1. For two W-lines with the same
 (`SampleId`,`HapIndex`,`SeqId`), their [`SeqSart`,`SeqEnd`) should have no
 overlaps. A `CompressedWalk` is defined as
 ```txt
-<walk> ::= ( `>' | `<' <segId> )+
+<walk> ::= ( `>' | `<' `@'? <segId> )+
 ```
-where `<segId>` corresponds either to the identifier of a segment or the
-identifier of a Q-line. A valid walk must exist in the graph.
+where `<segId>` corresponds either to the identifier of a segment or the identifier of a Q-line meta-segment. A valid walk must exist in the graph.
+`@` is placed in front of the identifier if it is the identifier of a meta-segment.
 
 ## Example
 
@@ -402,5 +401,5 @@ L	s11	+	s12	-	0M
 L	s12	-	s13	+	0M
 L	s11	+	s13	+	0M
 Q   q1  >s11<s12
-Z	NA12878	1	chr1	0	11	>q1>s13
+Z	NA12878	1	chr1	0	11	>@q1>s13
 ```

--- a/GFA1.md
+++ b/GFA1.md
@@ -1,7 +1,7 @@
 ---
 title: Graphical Fragment Assembly (GFA) Format Specification
 author: The GFA Format Specification Working Group
-date: 2022-06-07
+date: 2026-01-07
 ---
 
 The master version of this document can be found at  
@@ -11,7 +11,7 @@ The master version of this document can be found at
 
 The purpose of the GFA format is to capture sequence graphs as the product of an assembly, a representation of variation in genomes, splice graphs in genes, or even overlap between reads from long-read sequencing technology.
 
-The GFA format is a tab-delimited text format for describing a set of sequences and their overlap. The text is encoded in UTF-8 but is not allowed to use a codepoint value higher than 127. The first field of the line identifies the type of the line. Header lines start with `H`. Segment lines start with `S`. Link lines start with `L`. Jump lines (since v1.2) start with `J`. A containment line starts with `C`. A path line starts with `P`. Walk lines (since v1.1) start with `W`.
+The GFA format is a tab-delimited text format for describing a set of sequences and their overlap. The text is encoded in UTF-8 but is not allowed to use a codepoint value higher than 127. The first field of the line identifies the type of the line. Header lines start with `H`. Segment lines start with `S`. Link lines start with `L`. Jump lines (since v1.2) start with `J`. A containment line starts with `C`. A path line starts with `P`. Walk lines (since v1.1) start with `W`. Meta-segment lines (since v1.3) start with `Q`. Compressed walk lines (since v1.3) start with `Z`.
 
 ## Terminology
 

--- a/GFA1.md
+++ b/GFA1.md
@@ -50,6 +50,7 @@ All optional fields follow the `TAG:TYPE:VALUE` format where `TAG` is a two-char
 | `J`  | `[ !-~]+`                                             | [JSON][], excluding new-line and tab characters
 | `H`  | `[0-9A-F]+`                                           | Byte array in hex format
 | `B`  | `[cCsSiIf](,[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)+` | Array of integers or floats
+| `X`  | `[ -+\--~]+,[ -+\--~]+,(\*|[0-9]+),(\*|[0-9]+)(,[ -+\--~]+,[ -+\--~]+,(\*|[0-9]+),(\*|[0-9]+))*` | Array of database cross-references
 
 [JSON]: http://json.org/
 
@@ -324,4 +325,82 @@ The following lines describe the jump between reverse complement of segment 1 an
 ```
 J  1 - 2 + 100
 J  2 + 3 - * SC:i:1
+```
+
+# `Q` Rule line
+
+A Q-line defines part of a compressed walk that can be used as part of other
+compressed walks.
+
+## Required fields
+
+| Column | Field             | Type      | Regexp              | Description
+|--------|-------------------|-----------|---------------------|------------
+| 1      | `RecordType`      | Character | `Q`                 | Record type
+| 2      | `Name`            | String    | `[!-)+-<>-~][!-~]*` | Rule name
+| 3      | `CompressedWalk`  | String    | `([><][!-;=?-~]+)+` | Compressed Walk
+
+A `CompressedWalk` is defined as
+```txt
+<walk> ::= ( `>' | `<' <segId> )+
+```
+where `<segId>` corresponds either to the identifier of a segment or the
+identifier of a Q-line. A valid walk must exist in the graph.
+
+## Optional fields
+
+| Tag   | Type | Description    |
+|-------|------|----------------|
+| `LN`  | `i`  | Length in number of base pairs |
+| `LS`  | `i`  | Length in number of segments  |
+| `FN`  | `Z`  | Feature name |
+| `FT`  | `Z`  | Feature type |
+| `DB`  | `X`  | Database cross-references |
+
+## Example
+
+```txt
+Q	q1	>s1<s60>s75>q3>s77	FN:Z:MICA	FT:Z:gene	DB:X:EMBL,AA816246,*,*,NCBI_gi,100507436,437,8625		LN:8188	LS:9
+Q	q3	>s78>s79>s80>s80<s80
+```
+
+# `Z` Compressed walk line
+
+A walk line describes an oriented walk in the graph. It is only intended for a
+graph without overlaps between segments.
+Note that Z-lines can not use jump connections (introduced in v1.2).
+
+## Required fields
+
+| Column | Field             | Type      | Regexp                   | Description
+|--------|-------------------|-----------|--------------------------|------------
+| 1      | `RecordType`      | Character | `W`                      | Record type
+| 2      | `SampleId`        | String    | `[!-)+-<>-~][!-~]*`      | Sample identifier
+| 3      | `HapIndex`        | Integer   | `[0-9]+`                 | Haplotype index
+| 4      | `SeqId`           | String    | `[!-)+-<>-~][!-~]*`      | Sequence identifier
+| 5      | `SeqStart`        | Integer   | `\*\|[0-9]+`             | Optional Start position
+| 6      | `SeqEnd`          | Integer   | `\*\|[0-9]+`             | Optional End position (BED-like half-close-half-open)
+| 7      | `CompressedWalk`  | String    | `([><][!-;=?-~]+)+`      | Compressed Walk
+
+For a haploid sample, `HapIndex` takes 0. For a diploid or polyploid sample,
+`HapIndex` starts with 1. For two W-lines with the same
+(`SampleId`,`HapIndex`,`SeqId`), their [`SeqSart`,`SeqEnd`) should have no
+overlaps. A `CompressedWalk` is defined as
+```txt
+<walk> ::= ( `>' | `<' <segId> )+
+```
+where `<segId>` corresponds either to the identifier of a segment or the
+identifier of a Q-line. A valid walk must exist in the graph.
+
+## Example
+
+```txt
+S	s11	ACCTT
+S	s12	TC
+S	s13	GATT
+L	s11	+	s12	-	0M
+L	s12	-	s13	+	0M
+L	s11	+	s13	+	0M
+Q   q1  >s11<s12
+Z	NA12878	1	chr1	0	11	>q1>s13
 ```


### PR DESCRIPTION
Adds compressed walks as described in #130.

- GFA v1.3
- `Q` lines for meta-segments (non-terminals)
- `Z` lines for compressed walks
- Uses `@` to distinguish non-terminals from terminal symbols inside `Q` and `Z` lines